### PR TITLE
Harden button widget against script injection.

### DIFF
--- a/ui/widgets/button.js
+++ b/ui/widgets/button.js
@@ -66,7 +66,7 @@ $.widget( "ui.button", {
 			options.disabled = disabled;
 		}
 
-		this.originalLabel = this.isInput ? this.element.val() : this.element.html();
+		this.originalLabel = this.isInput ? this.element.val() : this.element.text();
 		if ( this.originalLabel ) {
 			options.label = this.originalLabel;
 		}
@@ -93,7 +93,7 @@ $.widget( "ui.button", {
 			if ( this.isInput ) {
 				this.element.val( this.options.label );
 			} else {
-				this.element.html( this.options.label );
+				this.element.text( this.options.label );
 			}
 		}
 		this._addClass( "ui-button", "ui-widget" );
@@ -249,7 +249,7 @@ $.widget( "ui.button", {
 
 				// If there is an icon, append it, else nothing then append the value
 				// this avoids removal of the icon when setting label text
-				this.element.html( value );
+				this.element.text( value );
 				if ( this.icon ) {
 					this._attachIcon( this.options.iconPosition );
 					this._attachIconSpace( this.options.iconPosition );


### PR DESCRIPTION
Replace button label DOM updates from `.html()` to `.text()`.  This prevents a label of, `<script>alert('test')</script>` from being injected as `html()`.